### PR TITLE
Convert to official CurseForge API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /.idea
+APIKEY

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "cursetool-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "console 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cursetool-rs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Maxwell L-T <maxwell.lt@live.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ If you have direnv and lorri set up, you can run `direnv allow` once to set up y
 
 You need to be running Nix with flakes enabled.
 
+Create a Curse API key at [CFCore](https://console.curseforge.com) and store it in a file named `APIKEY`.
+
 ## Development
 
 Run `nix develop`, then use Rust / cargo as normal.

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
 
 	defaultPackage = rustPlatform.buildRustPackage {
 	  pname = "cursetool-rs";
-	  version = "0.1.0";
+	  version = "0.2.0";
 
 	  src = builtins.filterSource
 	    (path: type: type != "symlink" && baseNameOf path != "target")

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
 
 	  doCheck = false;  # The tests require internet access.
 
-	  cargoSha256 = "sha256-hNFhxZWxmifopFJij5edtY8FWPLcrZwwt5mEpJGkHAI";
+	  cargoSha256 = "sha256-S87EM/atPVl0gJKo64ieBz3WI6Ed3D3bddamfNWPi54=";
 	};
   });
 }

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -3,18 +3,17 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use lazy_static::lazy_static;
-use regex::Regex;
-use reqwest::Url;
+use reqwest::{Url, header};
 use reqwest::blocking::{Client, RequestBuilder};
 use sha2::{Digest, Sha256};
 
 use crate::database::Database;
-use crate::model::{AddonInfo, CurseModFile, CurseModFileInfo};
+use crate::model::{AddonInfo, CurseModFile, CurseModFileInfo, CurseWrapper, Pagination};
 
 static DEFAULT_TIMEOUT: Duration = Duration::from_secs(86400);
 static INFINITE_TIMEOUT: Duration = Duration::from_secs(86400 * 365);
 lazy_static! {
-    static ref BASE_URL: Url = Url::parse("https://addons-ecs.forgesvc.net/api/v2/").unwrap();
+    static ref BASE_URL: Url = Url::parse("https://api.curseforge.com").unwrap();
 }
 // TODO: Implement with tokio.
 //static MAX_CONCURRENT_QUERIES: u32 = 2;
@@ -57,50 +56,77 @@ impl<'app> Downloader<'app> {
 }
 
 impl<'app> Downloader<'app> {
-    pub(crate) fn request_mod_files(&self, project_id: u32) -> Result<Vec<CurseModFile>> {
-        let url = BASE_URL
-            .join(&format!("addon/{}/files", project_id))?;
-        let data = self.get(url.clone())
-            .context(format!("Fetching files for project id {}", project_id))?;
-        let result: Vec<CurseModFile> = serde_json::from_str(&data)
-            .context(format!("Parsing files list as JSON for project id {}", project_id))?;
+    pub(crate) fn request_mod_files(&self, project_id: u32, game_version: &str) -> Result<Vec<CurseModFile>> {
+        let mut files = Vec::new();
+        let mut current_index = 0;
+        loop {
+            let url = BASE_URL
+                .join(&format!("/v1/mods/{}/files?gameVersion={}&pageSize=50&index={}", project_id, game_version, current_index))?;
+            let data = self.get(url.clone())
+                .context(format!("Fetching files for project id {} at index {}", project_id, current_index))?;
+            // Mutable to allow moving elements to the files vector
+            let mut result: CurseWrapper<Vec<CurseModFile>> = serde_json::from_str(&data)
+                .context(format!("Parsing files list as JSON for project id {}", project_id))?;
+            files.append(&mut result.data);
+            let page_info: Pagination = result.pagination.context(format!("No pagination in file listing for project id {}!", project_id))?;
+            current_index += 50;
+            if page_info.result_count == 0 {
+                break;
+            }
+        }
         // The URLs returned are not properly URL-encoded.
         // Specifically, the filename path needs to be encoded.
         //
         // Breaking the URL spec, curseforge requires + to be encoded.
         // This means we need to do the job 'manually'.
-        result
+        files
             .into_iter()
-            .map(|file| {
-                let url = Url::parse(&file.download_url).unwrap();
-                let filename = url.path_segments()
-                    .unwrap()
-                    .last()
-                    .unwrap();
-                // Sometimes the download URL is already encoded, and sometimes not.
-                // This encoder gives working output for the filename.
-                let encoded_filename = urlencoding::encode(
-                    &urlencoding::decode(filename).unwrap());
-                // We now need to construct a new url, *not* re-encoding it.
-                let mut base_url = url.clone();
-                base_url.path_segments_mut().unwrap()
-                    .pop();
-                let fixed_url = Url::parse(
-                    &format!("{}/{}", base_url.as_str(), &encoded_filename)).unwrap();
-                Ok(CurseModFile {
-                    download_url: fixed_url.to_string(),
-                    ..file
-                })
-            })
-        .collect()
+            .map(Downloader::encode_url)
+            .collect()
+    }
+
+    pub(crate) fn request_mod_file(&self, project_id: u32, file_id: u32) -> Result<CurseModFile> {
+        let url = BASE_URL
+            .join(&format!("/v1/mods/{}/files/{}", project_id, file_id))?;
+        let data = self.get(url.clone())
+            .context(format!("Fetching file id {} in project {}", file_id, project_id))?;
+        let result: CurseWrapper<CurseModFile> = serde_json::from_str(&data)
+            .context(format!("Parsing file id {} in project {}", file_id, project_id))?;
+        Downloader::encode_url(result.data)
+    }
+
+    fn encode_url(file: CurseModFile) -> Result<CurseModFile> {
+        let url = Url::parse(&file.download_url).unwrap();
+        let filename = url.path_segments()
+            .unwrap()
+            .last()
+            .unwrap();
+        // Sometimes the download URL is already encoded, and sometimes not.
+        // This encoder gives working output for the filename.
+        let encoded_filename = urlencoding::encode(
+            &urlencoding::decode(filename).unwrap());
+        // We now need to construct a new url, *not* re-encoding it.
+        let mut base_url = url.clone();
+        base_url.path_segments_mut().unwrap()
+            .pop();
+        let fixed_url = Url::parse(
+            &format!("{}/{}", base_url.as_str(), &encoded_filename)).unwrap();
+        Ok(CurseModFile {
+            download_url: fixed_url.to_string(),
+            ..file
+        })
     }
 }
 
 impl<'app> Downloader<'app> {
-    pub fn new(database: &'app Database) -> Self {
+    pub fn new(database: &'app Database, api_key: &str) -> Self {
+        let mut headers = header::HeaderMap::new();
+        headers.insert("x-api-key", header::HeaderValue::from_str(&api_key).expect(&format!("Invalid API key string: {}", api_key)));
         Downloader {
             cache_timeout: DEFAULT_TIMEOUT,
-            client: Client::new(),
+            client: Client::builder()
+                .default_headers(headers)
+                .build().unwrap(),
             database,
             rate_limiter: Mutex::new(()),
         }
@@ -120,27 +146,33 @@ impl<'app> Downloader<'app> {
         self.get_with_builder(url, |b| b)
     }
 
-    pub(crate) fn get_slug_from_webpage_url(&self, url: &str) -> Result<String> {
-        lazy_static! {
-            static ref RE: Regex = Regex::new(r".*/(?P<slug>.*)$").unwrap();
-        }
-        Ok(
-            RE.captures(url)
-                .and_then(|c| c.name("slug"))
-                .context(format!("Extracting slug from {}", url))?
-                .as_str().into()
-        )
-    }
-
     pub(crate) fn request_addon_info(&self, project_id: u32) -> Result<AddonInfo> {
         let url = BASE_URL
-            .join(&format!("addon/{}", project_id))?;
+            .join(&format!("/v1/mods/{}", project_id))?;
         let data = self.get_with_builder(url.clone(), |b| b)
                 .context(format!("Fetching addon info for project id {}", project_id))
                 .context(format!("From {:?}", url.as_str()))?;
-        serde_json::from_str(&data)
+        serde_json::from_str::<CurseWrapper<AddonInfo>>(&data)
                 .context(format!("Parsing addon info as JSON for project id {}. Data: {}", project_id, data))
                 .context(format!("From {}", url.as_str()))
+                .map(|d| d.data)
+    }
+
+    pub(crate) fn search_id_with_slug(&self, slug: &str) -> Result<u32> {
+        log::debug!("{}", format!("Searching ID for slug {}", slug));
+        let game_id = 432;
+        let class_id = 6;
+        let url = BASE_URL
+            .join(&format!("/v1/mods/search?gameId={}&classId={}&slug={}", game_id, class_id, slug))?;
+        let data = self.get_with_builder(url.clone(), |b| b)
+            .context(format!("Searching mods for project with slug {}", slug))
+            .context(format!("From {:?}", url.as_str()))?;
+        let result: CurseWrapper<Vec<AddonInfo>> = serde_json::from_str(&data)
+            .context(format!("Parsing search results as JSON for slug {}. Data: {}", slug, data))
+            .context(format!("From {}", url.as_str()))?;
+        result.data.get(0).map(|a| a.id)
+            .context(format!("No mods found with slug {}", slug))
+            .context(format!("Response: {}", data))
     }
 }
 
@@ -151,15 +183,9 @@ mod tests {
     fn with_downloader<F, X>(f: F) -> Result<X>
         where F: FnOnce(Downloader) -> Result<X> {
         let database = Database::for_tests().unwrap();
-        f(Downloader::new(&database))
-    }
-
-    #[test]
-    fn can_get_slug_from_url() {
-        let url = "https://www.curseforge.com/minecraft/mc-mods/hunger-overhaul";
-        let result = with_downloader(|d| d.get_slug_from_webpage_url(url)).unwrap();
-
-        assert_eq!(result, "hunger-overhaul");
+        let api_key = std::fs::read_to_string("APIKEY")
+            .context("Could not find a Curse API key!\nLogin at https://console.curseforge.com/ and save your key in a file named 'APIKEY'.")?;
+        f(Downloader::new(&database, api_key.trim()))
     }
 
     #[test]
@@ -169,7 +195,7 @@ mod tests {
 
         assert_eq!(result.name, "Hunger Overhaul");
         assert_eq!(result.id, project_id);
-        assert!(result.website_url.contains("hunger-overhaul"));
+        assert!(result.links.website_url.contains("hunger-overhaul"));
     }
 
 }

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -121,7 +121,7 @@ impl<'app> Downloader<'app> {
 impl<'app> Downloader<'app> {
     pub fn new(database: &'app Database, api_key: &str) -> Self {
         let mut headers = header::HeaderMap::new();
-        headers.insert("x-api-key", header::HeaderValue::from_str(&api_key).expect(&format!("Invalid API key string: {}", api_key)));
+        headers.insert("x-api-key", header::HeaderValue::from_str(&api_key).expect("Could not set API key as a header!")));
         Downloader {
             cache_timeout: DEFAULT_TIMEOUT,
             client: Client::builder()

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,16 +173,12 @@ impl<'app> App<'app> {
     }
 }
 
-
 fn main() -> Result<()> {
     TermLogger::init(LevelFilter::Info, Config::default(), TerminalMode::Mixed)?;
 
-    let api_key = std::fs::read_to_string("APIKEY")
-        .context("Could not find a Curse API key!\nLogin at https://console.curseforge.com/ and save your key in a file named 'APIKEY'.")?;
-
     let commandline = parse_commandline();
     let database = Database::from_filesystem()?;
-    let downloader = Downloader::new(&database, api_key.trim());
+    let downloader = Downloader::new(&database);
 
     let app = App::new(&commandline, &database, &downloader);
 
@@ -199,16 +195,13 @@ mod tests {
         where F: FnOnce(App) -> Result<X> {
         TermLogger::init(LevelFilter::Debug, Config::default(), TerminalMode::Mixed)?;
 
-        let api_key = std::fs::read_to_string("APIKEY")
-            .context("Could not find a Curse API key!\nLogin at https://console.curseforge.com/ and save your key in a file named 'APIKEY'.")?;
-
         let commandline = Commandline {
             mode,
             input_file: input_path,
             output_file: output_path,
         };
         let database = Database::for_tests()?;
-        let downloader = Downloader::new(&database, api_key.trim());
+        let downloader = Downloader::new(&database);
         let app = App::new(&commandline, &database, &downloader);
         f(app)
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,6 +6,21 @@ use anyhow::{Result, Context};
 use std::fs::File;
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct CurseWrapper<T> {
+    pub data: T,
+    pub pagination: Option<Pagination>
+}
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Pagination {
+    pub index: u32,
+    #[serde(rename = "pageSize")]
+    pub page_size: u32,
+    #[serde(rename = "resultCount")]
+    pub result_count: u32,
+    #[serde(rename = "totalCount")]
+    pub total_count: u32,
+}
+#[derive(Serialize, Deserialize, Debug)]
 pub struct MinecraftVersion {
     pub version: String
 }
@@ -23,11 +38,16 @@ pub struct CurseManifest {
     pub files: Vec<ModFile>
 }
 #[derive(Serialize, Deserialize, Debug)]
+pub struct AddonLinks {
+    #[serde(rename = "websiteUrl")]
+    pub website_url: String
+}
+#[derive(Serialize, Deserialize, Debug)]
 pub struct AddonInfo {
     pub name: String,
-    #[serde(rename = "websiteUrl")]
-    pub website_url: String,
-    pub id: u32
+    pub slug: String,
+    pub id: u32,
+    pub links: AddonLinks
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -50,7 +70,8 @@ pub struct YamlModFile {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct YamlMod {
     pub name: String,
-    pub id: u32,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub id: Option<u32>,
     #[serde(skip_serializing_if="Option::is_none")]
     pub side: Option<Side>,
     #[serde(skip_serializing_if="Option::is_none")]
@@ -130,7 +151,7 @@ pub struct CurseModFile {
     pub file_date: String,
     #[serde(rename = "downloadUrl")]
     pub download_url: String,
-    #[serde(rename = "gameVersion")]
+    #[serde(rename = "gameVersions")]
     pub game_version: Vec<String>
 }
 
@@ -187,7 +208,7 @@ impl YamlMod {
     pub fn with_files(name: &str, id: u32, file: YamlModFile) -> YamlMod {
         YamlMod {
             name: name.to_owned(),
-            id: id,
+            id: Some(id),
             side: None,
             required: None,
             default: None,


### PR DESCRIPTION
Now requires a valid API key in the `APIKEY` file, for standard operation and for tests. If running with `nix run`, the `APIKEY` file should be in your current directory.

Project IDs are back to being optional.